### PR TITLE
Add local build options for all platforms, not just MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ $ npm run dev
 
 ```bash
 # For windows
-$ npm run build:win
+$ npm run build:win:local
 
 # For macOS
-$ npm run build:mac
+$ npm run build:mac:local
 
 # For Linux
-$ npm run build:linux
+$ npm run build:linux:local
+
+Remove :local for publishing.
 ```


### PR DESCRIPTION
I was making a PKGBUILD for the AUR but noticed that the build instructions tell you to make it in a way that tries to push to Github, but that's pretty annoying if all you want to do is build the package, so this PR aims to remedy that.