### PR TITLE
Windows Steam Protocol conversion + fix/windows-freeze backup method

### DIFF
--- a/src/main/services/game-launch.service.ts
+++ b/src/main/services/game-launch.service.ts
@@ -13,158 +13,109 @@ const execAsync = promisify(exec)
  */
 async function isSteamRunning(): Promise<boolean> {
   try {
-    await execAsync('pgrep -x steam')
-    return true
+    switch (process.platform) {
+      case 'win32':
+        const { stdout } = await execAsync('tasklist /FI "IMAGENAME eq steam.exe" /FO CSV /NH')
+        return stdout.toLowerCase().includes('steam.exe')
+      
+      case 'darwin':
+        const { stdout: macStdout } = await execAsync('pgrep -x Steam')
+        return macStdout.trim().length > 0
+      
+      case 'linux':
+        const { stdout: linuxStdout } = await execAsync('pgrep -x steam')
+        return linuxStdout.trim().length > 0
+      
+      default:
+        return false
+    }
   } catch {
     return false
   }
 }
 
 /**
- * Checks if we can use Steam protocol (xdg-open available)
+ * Checks if we can use Steam protocol
  */
 async function canUseSteamProtocol(): Promise<boolean> {
   try {
-    await execAsync('which xdg-open')
-    return true
+    switch (process.platform) {
+      case 'win32':
+        return true
+      
+      case 'darwin':
+        return true
+      
+      case 'linux':
+        await execAsync('which xdg-open')
+        return true
+      
+      default:
+        return false
+    }
   } catch {
     return false
   }
 }
 
 /**
- * Launches the Balatro game
- * @returns A promise that resolves when the game is launched
+ * Launches Steam if it's not running
  */
-async function launchGame(): Promise<void> {
-  loggerService.info('Launching Balatro game')
-
-  // Get the game directory
-  const gameDir = await modInstallationService.getGameDirectory()
-  if (!gameDir) {
-    throw new Error('Game directory not found. Please set it in settings.')
-  }
-
-  // Check if lovely console is enabled
-  const lovelyConsoleEnabled = false // Default to disabled for now
-
-  // Create a path object from the game directory
-  const gamePath = path.resolve(gameDir)
-
-  // Platform-specific launch logic
-  if (process.platform === 'darwin') {
-    // macOS code
-    const lovelyInstalled = await modInstallationService.isLovelyInstalled()
-    const balatroExecutable = path.join(gamePath, 'Balatro.app/Contents/MacOS/love')
-
-    if (lovelyInstalled) {
-      // If lovely is installed, use it
-      const lovelyPath = path.join(gamePath, 'liblovely.dylib')
-
-      // If the console is disabled, add the flag
-      const disableArg = !lovelyConsoleEnabled ? ' --disable-console' : ''
-
-      // Instead of using double quotes which cause conflicts in AppleScript,
-      // wrap the file paths in single quotes.
-      const commandLine = `cd '${gamePath}' && DYLD_INSERT_LIBRARIES='${lovelyPath}' '${balatroExecutable}'${disableArg}`
-
-      // Construct the AppleScript command to run the command_line in Terminal.
-      const applescript = `tell application "Terminal" to do script "${commandLine}"`
-
-      spawn('osascript', ['-e', applescript]).on('error', (err) => {
-        loggerService.error('Failed to launch game:', err)
-        throw new Error(`Failed to launch game: ${err.message}`)
-      })
-    } else {
-      // If lovely is not installed, launch directly
-      spawn(balatroExecutable, [], { cwd: gamePath }).on('error', (err) => {
-        loggerService.error('Failed to launch game:', err)
-        throw new Error(`Failed to launch game: ${err.message}`)
-      })
-    }
-  } else if (process.platform === 'win32') {
-    // Windows code
-    // Find the executable file in the directory
-    const exePath = findExecutableInDirectory(gamePath)
-    if (!exePath) {
-      throw new Error(`No executable found in ${gamePath}`)
-    }
-
-    const dllPath = path.join(gamePath, 'version.dll')
-
-    // If version.dll doesn't exist, check if lovely is installed
-    if (!fs.existsSync(dllPath)) {
-      const lovelyInstalled = await modInstallationService.isLovelyInstalled()
-      if (!lovelyInstalled) {
-        loggerService.info('Lovely not installed, launching game without it')
-      }
-    }
-
-    try {
-      // For Windows, we can create a batch file to launch the game with arguments if needed
-      if (!lovelyConsoleEnabled) {
-        // Create a batch file to launch with --disable-console
-        const batchPath = path.join(gamePath, 'launch_balatro.bat')
-        const batchContent = `@echo off
-cd /d "${gamePath}"
-start "" "${exePath}" --disable-console
-`
-        // Write the batch file
-        fs.writeFileSync(batchPath, batchContent)
-
-        // Launch the batch file
-        await shell.openPath(batchPath)
-        loggerService.info('Launched game with --disable-console using batch file')
-      } else {
-        // Launch the executable directly
-        await shell.openPath(exePath)
-        loggerService.info('Launched game directly using shell.openPath')
-      }
-    } catch (err) {
-      loggerService.error('Failed to launch game:', err)
-      throw new Error(`Failed to launch game: ${err instanceof Error ? err.message : String(err)}`)
-    }
-
-    loggerService.info(`Launched game from ${exePath}`)
-  } else if (process.platform === 'linux') {
-    // Linux code - Launch via Steam with Proton
-    const BALATRO_STEAM_APP_ID = '2379780'
-
-    try {
-      // First, try to detect if Steam is running
-      const steamRunning = await isSteamRunning()
-      if (!steamRunning) {
-        loggerService.info('Steam is not running, attempting to start Steam...')
-        // Try to start Steam
+async function launchSteam(): Promise<void> {
+  loggerService.info('Steam is not running, attempting to start Steam...')
+  
+  try {
+    switch (process.platform) {
+      case 'win32':
+        spawn('steam.exe', [], { detached: true, stdio: 'ignore' })
+        break
+      
+      case 'darwin':
+        spawn('open', ['-a', 'Steam'], { detached: true, stdio: 'ignore' })
+        break
+      
+      case 'linux':
         spawn('steam', [], { detached: true, stdio: 'ignore' })
-        // Wait a bit for Steam to start
-        await new Promise((resolve) => setTimeout(resolve, 3000))
-      }
-
-      // Check if we can launch via Steam protocol
-      const steamProtocolAvailable = await canUseSteamProtocol()
-
-      if (!steamProtocolAvailable) {
-        throw new Error('Steam protocol not available')
-      }
-
-      // Use steam:// protocol
-      const steamUrl = `steam://rungameid/${BALATRO_STEAM_APP_ID}`
-      loggerService.info(`Launching Balatro via Steam protocol: ${steamUrl}`)
-      loggerService.info('Note: Using Steam launch options configured in Steam client')
-
-      spawn('xdg-open', [steamUrl]).on('error', (err) => {
-        loggerService.error('Failed to launch via Steam protocol:', err)
-        throw new Error(`Failed to launch via Steam protocol: ${err.message}`)
-      })
-
-      loggerService.info('Successfully launched Balatro on Linux')
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-      throw new Error(`Failed to launch Balatro on Linux: ${errorMessage}`)
+        break
+      
+      default:
+        throw new Error(`Unsupported platform: ${process.platform}`)
     }
-  } else {
-    throw new Error(`Unsupported platform: ${process.platform}`)
+    
+    await new Promise((resolve) => setTimeout(resolve, 3000))
+  } catch (error) {
+    loggerService.error('Failed to start Steam:', error)
+    throw error
+  }
+}
+
+/**
+ * Opens a URL using the appropriate method for the platform
+ */
+async function openUrl(url: string): Promise<void> {
+  try {
+    switch (process.platform) {
+      case 'win32':
+        await shell.openExternal(url)
+        break
+      
+      case 'darwin':
+        await shell.openExternal(url)
+        break
+      
+      case 'linux':
+        spawn('xdg-open', [url]).on('error', (err) => {
+          loggerService.error('Failed to launch via Steam protocol:', err)
+          throw new Error(`Failed to launch via Steam protocol: ${err.message}`)
+        })
+        break
+      
+      default:
+        throw new Error(`Unsupported platform: ${process.platform}`)
+    }
+  } catch (error) {
+    loggerService.error('Failed to open URL:', error)
+    throw error
   }
 }
 
@@ -178,10 +129,8 @@ function findExecutableInDirectory(dir: string): string | null {
     return null
   }
 
-  // Create a Vec to hold all executable files
   const executables: string[] = []
 
-  // First, collect all executable files in the directory
   const entries = fs.readdirSync(dir)
   for (const entry of entries) {
     const entryPath = path.join(dir, entry)
@@ -194,7 +143,6 @@ function findExecutableInDirectory(dir: string): string | null {
     return null
   }
 
-  // First, look for any executable with "balatro" in the name (case-insensitive)
   for (const exe of executables) {
     const fileName = path.basename(exe).toLowerCase()
     if (fileName.includes('balatro')) {
@@ -202,8 +150,134 @@ function findExecutableInDirectory(dir: string): string | null {
     }
   }
 
-  // If no Balatro-specific executable was found, return the first executable
   return executables[0]
+}
+
+/**
+ * Launches the game directly (backup method for Windows, primary method for macOS)
+ */
+async function launchGameDirectly(): Promise<void> {
+  loggerService.info('Launching Balatro game directly')
+
+  const gameDir = await modInstallationService.getGameDirectory()
+  if (!gameDir) {
+    throw new Error('Game directory not found. Please set it in settings.')
+  }
+
+  const lovelyConsoleEnabled = false
+  const gamePath = path.resolve(gameDir)
+
+  if (process.platform === 'darwin') {
+    // macOS direct launch with mod support
+    const lovelyInstalled = await modInstallationService.isLovelyInstalled()
+    const balatroExecutable = path.join(gamePath, 'Balatro.app/Contents/MacOS/love')
+
+    if (lovelyInstalled) {
+      const lovelyPath = path.join(gamePath, 'liblovely.dylib')
+      const disableArg = !lovelyConsoleEnabled ? ' --disable-console' : ''
+      const commandLine = `cd '${gamePath}' && DYLD_INSERT_LIBRARIES='${lovelyPath}' '${balatroExecutable}'${disableArg}`
+      const applescript = `tell application "Terminal" to do script "${commandLine}"`
+
+      spawn('osascript', ['-e', applescript]).on('error', (err) => {
+        loggerService.error('Failed to launch game:', err)
+        throw new Error(`Failed to launch game: ${err.message}`)
+      })
+    } else {
+      spawn(balatroExecutable, [], { cwd: gamePath }).on('error', (err) => {
+        loggerService.error('Failed to launch game:', err)
+        throw new Error(`Failed to launch game: ${err.message}`)
+      })
+    }
+  } else if (process.platform === 'win32') {
+    // Windows direct launch (backup method)
+    const exePath = findExecutableInDirectory(gamePath)
+    if (!exePath) {
+      throw new Error(`No executable found in ${gamePath}`)
+    }
+
+    const dllPath = path.join(gamePath, 'version.dll')
+
+    if (!fs.existsSync(dllPath)) {
+      const lovelyInstalled = await modInstallationService.isLovelyInstalled()
+      if (!lovelyInstalled) {
+        loggerService.info('Lovely not installed, launching game without it')
+      }
+    }
+
+    try {
+      if (!lovelyConsoleEnabled) {
+        const batchPath = path.join(gamePath, 'launch_balatro.bat')
+        const batchContent = `@echo off
+cd /d "${gamePath}"
+start "" "${exePath}" --disable-console
+`
+        fs.writeFileSync(batchPath, batchContent)
+        await shell.openPath(batchPath)
+        loggerService.info('Launched game with --disable-console using batch file')
+      } else {
+        await shell.openPath(exePath)
+        loggerService.info('Launched game directly using shell.openPath')
+      }
+    } catch (err) {
+      loggerService.error('Failed to launch game:', err)
+      throw new Error(`Failed to launch game: ${err instanceof Error ? err.message : String(err)}`)
+    }
+
+    loggerService.info(`Launched game from ${exePath}`)
+  } else {
+    throw new Error(`Direct launch not supported on platform: ${process.platform}`)
+  }
+}
+
+/**
+ * Launches the Balatro game
+ * @returns A promise that resolves when the game is launched
+ */
+async function launchGame(): Promise<void> {
+  loggerService.info('Launching Balatro game')
+
+  const BALATRO_STEAM_APP_ID = '2379780'
+
+  // macOS always uses direct launch (doesn't support modded version through Steam)
+  if (process.platform === 'darwin') {
+    await launchGameDirectly()
+    return
+  }
+
+  // For Windows and Linux, try Steam protocol first, then fallback to direct launch
+  try {
+    const steamRunning = await isSteamRunning()
+    if (!steamRunning) {
+      await launchSteam()
+    }
+
+    const steamProtocolAvailable = await canUseSteamProtocol()
+
+    if (!steamProtocolAvailable) {
+      if (process.platform === 'win32') {
+        loggerService.info('Steam protocol not available, falling back to direct launch')
+        await launchGameDirectly()
+        return
+      } else {
+        throw new Error('Steam protocol not available')
+      }
+    }
+
+    const steamUrl = `steam://rungameid/${BALATRO_STEAM_APP_ID}`
+    loggerService.info(`Launching Balatro via Steam protocol: ${steamUrl}`)
+
+    await openUrl(steamUrl)
+
+    loggerService.info(`Successfully launched Balatro on ${process.platform}`)
+  } catch (error) {
+    if (process.platform === 'win32') {
+      loggerService.info('Steam protocol failed, falling back to direct launch')
+      await launchGameDirectly()
+    } else {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      throw new Error(`Failed to launch Balatro on ${process.platform}: ${errorMessage}`)
+    }
+  }
 }
 
 export const gameLaunchService = {


### PR DESCRIPTION
- Converts windows to use Steam Protocol when available, let steam handle everything
  - Will definitely prevent freezing ("definitely" being personal opinion)
- If Steam Protocol fails we create a batch file and launch Balatro through that (the fix proposed in branch fix/windows-freeze)
  - This most likely also fixes the freezing issue but it is hard to test


```mermaid
flowchart TD
    A[Start] --> B{Operating System}
    
    B -->|Linux| C{Steam Protocol Available?}
    B -->|Windows| D{Steam Protocol Available?}
    B -->|Mac| E[Launch directly<br/>Can't launch modded through steam]
    
    C -->|Yes| F[Launch using steam protocol]
    C -->|No| G[Fails<br/>Requires Proton to launch the game]
    
    D -->|Yes| H[Launch using steam protocol]
    D -->|No| I[Launch directly]
```

Mac launching successfully still needs to be verified, the logic shouldn't have changed but I did move some code around so I might have messed something up